### PR TITLE
Fix: Ensure discord_message_id field exists for unpublished activity queries

### DIFF
--- a/src/db/activities.py
+++ b/src/db/activities.py
@@ -45,7 +45,8 @@ def create_activity(activity: Activity, transaction=None) -> DocumentReference:
     leader_ref = db.collection('leaders').document(activity.leader.document_id)
     place_ref = db.collection('places').document(activity.place.document_id)
 
-    # Build data dict and omit None values
+    # Build data dict
+    # Note: discord_message_id is kept even when None so we can query for unpublished activities
     data = {
         'activity_permalink': activity.activity_permalink,
         'title': activity.title,
@@ -56,10 +57,10 @@ def create_activity(activity: Activity, transaction=None) -> DocumentReference:
         'place_ref': place_ref,
         'activity_type': activity.activity_type,
         'branch': activity.branch,
-        'discord_message_id': activity.discord_message_id,
+        'discord_message_id': activity.discord_message_id,  # Always include, even if None
     }
-    # Remove keys with None values
-    data = {k: v for k, v in data.items() if v is not None}
+    # Remove other keys with None values (but keep discord_message_id)
+    data = {k: v for k, v in data.items() if k == 'discord_message_id' or v is not None}
 
     if transaction:
         transaction.set(doc_ref, data)


### PR DESCRIPTION
Fixes #13

## Problem
The publishing catchup job was finding 0 unpublished activities even though unpublished activities existed in Firestore.

## Root Cause
In Firestore, `field == None` queries only match documents where:
- The field **exists** with a **null value**

They do **NOT** match documents where:
- The field is **missing entirely**

Our `create_activity` function was removing all `None` values from the data dict before saving, so `discord_message_id` was **missing** (not `null`) for unpublished activities.

## Solution
Always include the `discord_message_id` field in activity documents, even when it's `None`. This ensures the query `.where(field_path='discord_message_id', op_string='==', value=None)` correctly matches unpublished activities.

## Testing
- ✅ All existing tests pass
- ✅ Unit tests for catchup query logic
- ✅ Transactional activity creation tests

## Deployment Note
After merging, you'll need to run `pulumi up` to deploy the fix. Existing activities in Firestore that are missing the `discord_message_id` field won't be found until they're either:
1. Manually updated to have `discord_message_id: null`, or
2. The catchup query is changed to use a different approach (like checking for field existence)