### PR TITLE
Improve base search URI

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -263,7 +263,7 @@ This cloud function should query the `activities` collection for documents witho
 The activities search endpoint from the Mountaineers website presents a single `GET` endpoint as follows:
 
 ```
-https://www.mountaineers.org/activities/activities/@@faceted_query?b_start:int=[start_index]&c4%5B%5D=[type]
+https://www.mountaineers.org/search/@@faceted_query?b_start:int=[start_index]&c4%5B%5D=[type]
 ```
 
 The `[start_index]` parameter is a zero-based record number to start the page of results at; pages are of length up to 20, with a page of fewer than 20 records indicating the end of the results.  The `[type]` parameter is one of the following activity types:

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -64,7 +64,7 @@ def fetch_search_results(start_index: int = 0, activity_type: str = 'Backcountry
     """
     from urllib.parse import urlencode
 
-    base_url = 'https://www.mountaineers.org/activities/activities/@@faceted_query'
+    base_url = 'https://www.mountaineers.org/search/@@faceted_query'
 
     # Build query parameters
     params = {


### PR DESCRIPTION
Updates the base search URI to /search/ to capture more results, as identified in Issue #18. Also updates the specification to reflect this change.