### PR TITLE
Use approved scraping URL with single-pass extraction (Issue #31)

### DIFF
--- a/ARCHITECTURE.txt
+++ b/ARCHITECTURE.txt
@@ -15,16 +15,29 @@
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                            SEARCH PHASE                                     │
+│                   SEARCH PHASE (single-pass, issue #31)                     │
 │                                                                             │
 │  ┌──────────────────┐          ┌─────────────────┐                        │
 │  │   Mountaineers   │◄─────────│    Searcher     │                        │
-│  │     Website      │  GET     │    Function     │                        │
-│  │ (Search Results) │          └────────┬────────┘                        │
-│  └──────────────────┘                   │                                  │
+│  │  Approved URL    │  GET     │    Function     │                        │
+│  │  @@faceted_query │  (bypass └────────┬────────┘                        │
+│  │  (c4 facet)      │   header +        │                                  │
+│  └──────────────────┘  cache-bust)     │ store activity + leader,         │
 │                                          │ update status                    │
 │                            ┌─────────────▼──────────────┐                  │
 │                            │       Firestore            │                  │
+│                            │  ┌──────────────────────┐  │                  │
+│                            │  │ activities           │  │                  │
+│                            │  │   - title, date      │  │                  │
+│                            │  │   - activity_type    │  │                  │
+│                            │  │   - leader_ref       │  │                  │
+│                            │  │   - place_name       │  │                  │
+│                            │  │   - branch           │  │                  │
+│                            │  │   - discord_msg_id   │  │                  │
+│                            │  └──────────────────────┘  │                  │
+│                            │  ┌──────────────────────┐  │                  │
+│                            │  │ leaders              │  │                  │
+│                            │  └──────────────────────┘  │                  │
 │                            │  ┌──────────────────────┐  │                  │
 │                            │  │ bookkeeping          │  │                  │
 │                            │  │   - search_status    │  │                  │
@@ -35,51 +48,20 @@
 │                                          │ enqueue tasks                    │
 │                                          ▼                                  │
 │                         ┌─────────────────────────────┐                    │
-│                         │   search-queue (10/min)     │─┐ pagination       │
-│                         │   scrape-queue (30/min)     │ │                  │
-│                         └─────────────────────────────┘ │                  │
-│                                          │               │                  │
-│                                          └───────────────┘                  │
+│                         │  search-queue (10/min) ─┐    │ pagination        │
+│                         │  publish-queue (5/min)  │    │                   │
+│                         └─────────────────────────┼────┘                   │
+│                                          ▲        │                        │
+│                                          └────────┘ (next page)            │
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                           SCRAPE PHASE                                      │
+│                    SCRAPE PHASE (DORMANT - issue #31)                       │
 │                                                                             │
-│  ┌──────────────────┐          ┌─────────────────┐                        │
-│  │   Mountaineers   │◄─────────│    Scraper      │                        │
-│  │     Website      │  GET     │    Function     │                        │
-│  │ (Activity Detail)│          └────────┬────────┘                        │
-│  └──────────────────┘                   │                                  │
-│                                          │ store                            │
-│                            ┌─────────────▼──────────────┐                  │
-│                            │       Firestore            │                  │
-│                            │  ┌──────────────────────┐  │                  │
-│                            │  │ activities           │  │                  │
-│                            │  │   - title            │  │                  │
-│                            │  │   - date             │  │                  │
-│                            │  │   - activity_type    │  │                  │
-│                            │  │   - leader_ref       │  │                  │
-│                            │  │   - place_ref        │  │                  │
-│                            │  │   - discord_msg_id   │  │                  │
-│                            │  └──────────────────────┘  │                  │
-│                            │  ┌──────────────────────┐  │                  │
-│                            │  │ leaders              │  │                  │
-│                            │  └──────────────────────┘  │                  │
-│                            │  ┌──────────────────────┐  │                  │
-│                            │  │ places               │  │                  │
-│                            │  └──────────────────────┘  │                  │
-│                            │  ┌──────────────────────┐  │                  │
-│                            │  │ bookkeeping          │  │                  │
-│                            │  │   - scrape_status    │  │                  │
-│                            │  │   - last_success     │  │                  │
-│                            │  └──────────────────────┘  │                  │
-│                            └─────────────────────────────┘                  │
-│                                          │                                  │
-│                                          │ enqueue task                     │
-│                                          ▼                                  │
-│                         ┌─────────────────────────────┐                    │
-│                         │  publish-queue (5/min)      │                    │
-│                         └─────────────────────────────┘                    │
+│  Detail pages remain Cloudflare-protected, so nothing enqueues scrape      │
+│  tasks. The Scraper function and scrape-queue (30/min) are retained as a    │
+│  fallback / manual-reprocessing path and, if detail pages become reachable  │
+│  again, populate a fully linkable place_ref (places collection).            │
 └─────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -157,19 +139,19 @@
 
   Cloud Functions:
     • searcher:           ~720 invocations/month   (512MB, 540s timeout)
-    • scraper:            ~10,000 invocations/month (512MB, 540s timeout)
+    • scraper:            DORMANT (issue #31; fallback only)
     • publisher:          ~10,000 invocations/month (256MB, 540s timeout)
     • publishing-catchup: ~720 invocations/month   (256MB, 540s timeout)
 
   Cloud Tasks Queues:
     • search-queue:  10 dispatches/min, 1 concurrent, 3 retries
-    • scrape-queue:  30 dispatches/min, 5 concurrent, 3 retries
+    • scrape-queue:  30 dispatches/min, 5 concurrent, 3 retries (DORMANT)
     • publish-queue: 5 dispatches/min, 1 concurrent, 3 retries
 
   Firestore Collections:
     • activities:   ~14 new documents per poll
     • leaders:      ~5-10 documents (deduplicated)
-    • places:       ~5-10 documents (deduplicated)
+    • places:       populated only by the dormant scraper path (issue #31)
     • bookkeeping:  1 document (status tracking)
 
   Total Cost: $0/month (within free tier limits)

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -37,6 +37,7 @@ export GCP_REGION=us-central1
 export DISCORD_CHANNEL_ID=123456789012345678  # Dev Discord channel
 export DISCORD_BOT_TOKEN_SECRET=discord-bot-token
 export DEPLOY_ENV=dev
+# export MTN_SCRAPER_HEADER_VALUE=MountaineersDevRequest  # Cloudflare bypass header (issue #31); defaults if unset
 ```
 
 **prod-env.sh:**
@@ -47,6 +48,7 @@ export GCP_REGION=us-central1
 export DISCORD_CHANNEL_ID=987654321098765432  # Prod Discord channel
 export DISCORD_BOT_TOKEN_SECRET=discord-bot-token
 export DEPLOY_ENV=prod
+# export MTN_SCRAPER_HEADER_VALUE=MountaineersDevRequest  # Cloudflare bypass header (issue #31); defaults if unset
 ```
 
 Make them executable:

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -42,8 +42,8 @@ All Cloud Functions are deployed with IAM authentication required. To invoke the
 
 ### Deployed Functions
 
-- `searcher` - Search for new activities (triggered by Cloud Scheduler)
-- `scraper` - Scrape activity details (triggered by Cloud Tasks)
+- `searcher` - Single-pass: build activities from the approved listing and enqueue publish tasks (triggered by Cloud Scheduler). See issue #31.
+- `scraper` - **Dormant** (issue #31): detail pages are Cloudflare-protected, so nothing enqueues scrape tasks. Retained for fallback / manual reprocessing.
 - `publisher` - Publish to Discord (triggered by Cloud Tasks)
 - `publishing-catchup` - Retry failed publications (triggered by Cloud Scheduler)
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ Built with **Google Cloud Functions (2nd gen)**, Cloud Tasks, and Firestore.
 ```
 Cloud Scheduler (every 60 min)
     ↓
-Searcher Function → Cloud Tasks → Scraper Function → Cloud Tasks → Publisher Function
-    ↓                                   ↓                              ↓
-Search Results                      Firestore                      Discord Channel
+Searcher Function → Cloud Tasks → Publisher Function
+    ↓                                  ↓
+Firestore                         Discord Channel
 ```
+
+The Mountaineers site is behind Cloudflare, and only an approved listing URL is
+reachable (with a bypass header); per-activity detail pages are not. The Searcher
+therefore runs **single-pass** — it builds each activity directly from the listing
+and enqueues a publish task. The Scraper function / `scrape-queue` are retained but
+**dormant** as a fallback. See [issue #31](https://github.com/prb/mounties-activity-publisher/issues/31).
 
 ## Quick Start
 
@@ -261,10 +267,11 @@ gcloud projects add-iam-policy-binding $GCP_PROJECT \
 3. Check publisher function logs: `gcloud functions logs read publisher --region=us-central1`
 4. Verify bot has "Send Messages" permission in Discord channel
 
-### Activities not being scraped
-1. Check searcher function logs
-2. Verify Cloud Tasks queues are processing: `gcloud tasks queues describe scrape-queue --location=us-central1`
-3. Check for Firestore permission errors
+### Activities not being published
+1. Check searcher function logs (the searcher is single-pass — it builds activities from the approved listing and enqueues publish tasks directly; see issue #31)
+2. Verify the search and publish queues are processing: `gcloud tasks queues describe search-queue --location=us-central1` and `gcloud tasks queues describe publish-queue --location=us-central1` (note: `scrape-queue` is dormant)
+3. Confirm the approved listing is reachable — a Cloudflare `403` means the `mtn-approved-scraper` header/`MTN_SCRAPER_HEADER_VALUE` is missing or wrong
+4. Check for Firestore permission errors
 
 See [PHASE5_README.md](PHASE5_README.md#troubleshooting) for detailed troubleshooting.
 

--- a/architecture.puml
+++ b/architecture.puml
@@ -18,8 +18,8 @@ cloud "Cloud Scheduler\n(search: hourly)" as search_scheduler CLOUD
 cloud "Cloud Scheduler\n(catchup: :30)" as catchup_scheduler CLOUD
 
 ' Cloud Functions
-component "Searcher\nFunction" as searcher FUNCTION
-component "Scraper\nFunction" as scraper FUNCTION
+component "Searcher\nFunction\n(single-pass)" as searcher FUNCTION
+component "Scraper\nFunction\n(DORMANT)" as scraper FUNCTION
 component "Publisher\nFunction" as publisher FUNCTION
 component "Publishing Catchup\nFunction" as catchup FUNCTION
 component "Pause Processing\nFunction" as pause FUNCTION
@@ -28,7 +28,7 @@ component "Drain Queues\nFunction" as drain FUNCTION
 
 ' Cloud Tasks Queues
 queue "search-queue\n10/min" as search_queue QUEUE
-queue "scrape-queue\n30/min" as scrape_queue QUEUE
+queue "scrape-queue\n30/min\n(DORMANT)" as scrape_queue QUEUE
 queue "publish-queue\n5/min" as publish_queue QUEUE
 
 ' Storage
@@ -43,18 +43,19 @@ database "Firestore\nCollections" as firestore STORAGE {
 ' Secret Manager
 storage "Secret Manager\ndiscord-bot-token" as secrets STORAGE
 
-' Flow - Search path
+' Flow - Search path (single-pass, issue #31)
 search_scheduler --> searcher : trigger hourly
-searcher --> mountaineers : GET search results
+searcher --> mountaineers : GET approved listing\n(bypass header + cache-bust)
 searcher --> search_queue : enqueue next page
-searcher --> firestore : update bookkeeping
+searcher --> firestore : store activity,\nleader, bookkeeping
 search_queue --> searcher
+searcher --> publish_queue : enqueue activity ID
 
-searcher --> scrape_queue : enqueue detail URLs
-scrape_queue --> scraper : process
-scraper --> mountaineers : GET activity detail
-scraper --> firestore : store activity,\nleader, place,\nbookkeeping
-scraper --> publish_queue : enqueue activity ID
+' Dormant fallback path (detail pages Cloudflare-protected)
+scrape_queue ..> scraper : (dormant)
+scraper ..> mountaineers : GET activity detail
+scraper ..> firestore : store activity,\nleader, place
+scraper ..> publish_queue : enqueue activity ID
 
 ' Flow - Publishing path
 publish_queue --> publisher : process

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,6 +16,9 @@ REGION="${GCP_REGION:-us-central1}"
 DISCORD_BOT_TOKEN_SECRET="${DISCORD_BOT_TOKEN_SECRET:-discord-bot-token}"
 DISCORD_CHANNEL_ID="${DISCORD_CHANNEL_ID:-your-channel-id}"
 DEPLOY_ENV="${DEPLOY_ENV:-prod}"
+# Cloudflare bypass header value for the approved scraping URL (issue #31).
+# Low-sensitivity config (published in the issue); overridable via env.
+MTN_SCRAPER_HEADER_VALUE="${MTN_SCRAPER_HEADER_VALUE:-MountaineersDevRequest}"
 SCHEDULER_SERVICE_ACCOUNT="scheduler-invoker@${PROJECT_ID}.iam.gserviceaccount.com"
 
 # Colors for output
@@ -135,7 +138,7 @@ gcloud functions deploy searcher \
     --entry-point=searcher \
     --trigger-http \
     --no-allow-unauthenticated \
-    --set-env-vars="GCP_PROJECT=$PROJECT_ID,GCP_LOCATION=$REGION,APP_VERSION=$GIT_SHA,DEPLOY_ENV=$DEPLOY_ENV" \
+    --set-env-vars="GCP_PROJECT=$PROJECT_ID,GCP_LOCATION=$REGION,APP_VERSION=$GIT_SHA,DEPLOY_ENV=$DEPLOY_ENV,MTN_SCRAPER_HEADER_VALUE=$MTN_SCRAPER_HEADER_VALUE" \
     --timeout=540s \
     --memory=512MB \
     --quiet

--- a/queues.yaml
+++ b/queues.yaml
@@ -12,6 +12,9 @@ queue:
       max_backoff: 60s
       max_doublings: 3
 
+  # DORMANT (issue #31): the searcher is now single-pass and builds activities
+  # directly from the listing, so nothing enqueues scrape tasks. The scrape-queue
+  # and scraper function are retained as a fallback / manual-reprocessing path.
   - name: scrape-queue
     rate_limits:
       max_dispatches_per_second: 0.5  # ~30 requests per minute

--- a/spec.md
+++ b/spec.md
@@ -130,6 +130,7 @@ The following configuration information will be stored:
   - Secret name format: `discord-bot-token` (or `{env}-discord-bot-token` for multi-env in same project)
 - The *Discord Channel ID* will be passed as an environment variable to the publisher function.
   - Different channels should be used for different environments (dev vs prod)
+- The *Mountaineers scraper bypass header value* will be passed to the searcher function as the `MTN_SCRAPER_HEADER_VALUE` environment variable (issue #31). It is low-sensitivity config (published in the issue) with a sensible default; it must never be logged.
 
 ### Scheduling, Retries, Backoff, and Catchup
 
@@ -156,7 +157,8 @@ The persistent cache will contain an `activities` collection.  Each `activity` d
 - `description` (text string): A brief description of the activity.
 - `difficulty_rating` (array): The difficulty rating of the activity.
 - `activity_date` (date and time): The date of the activity, stored in UTC.
-- `place_ref` (reference): A reference to a document in the `places` collection.
+- `place_ref` (reference, optional): A reference to a document in the `places` collection. Only present for detail-page (dormant scraper) activities; single-pass listing activities omit it (see `place_name`).
+- `place_name` (text string, optional): The plain-text route/place name recovered from the title, used by single-pass listing activities that have no linkable `place_ref`.
 - `url` (text string): The URL of the activity detail page.
 - `branch` (text string): The sponsoring branch for the activity.
 - `leader_ref` (reference): A reference to a document in the `leaders` collection.
@@ -244,9 +246,15 @@ The `content` of the request should be based on the `activity`, `leader`, and `p
 
 ```
 📆 {{activity.activity_date in YYYY-MM-DD format in Pacific timezone}} {{emoji for activity.activity_type}} [{{activity.title}}]({{activity.activity_permalink}})
-Leader: [{{activity.leader.name}}](<{{activity.leader.leader_permalink}}>) at [{{activity.place.name}}](<{{activity.place.place_permalink}}>)
+Leader: [{{activity.leader.name}}](<{{activity.leader.leader_permalink}}>){{place clause}}
 Difficulty Ratings: {{comma-concatenated activity.difficulty_rating with optional emojis}}
 ```
+
+The **place clause** depends on what place data the activity has (see the single-pass note below):
+
+- A linkable `place` (from a detail-page scrape): ` at [{{activity.place.name}}](<{{activity.place.place_permalink}}>)`
+- Only a `place_name` (single-pass listing activity): ` at {{activity.place_name}}` (plain text, no link)
+- Neither: the clause is omitted entirely.
 
 (Note that the syntax `[anchor text](<url>)` is used to create a hyperlink that does not render a preview in the channel.)
 
@@ -270,33 +278,85 @@ This cloud function should query the `activities` collection for documents witho
 
 ## Mountaineers Website Search API, Polling, and Scraping
 
+> **Cloudflare scraper protection (issue #31).** The Mountaineers implemented
+> Cloudflare protection and provided a single **approved** listing URL that can be
+> accessed with a custom bypass header. Only the approved listing path (and its
+> `@@faceted_query` child) is bypassed — **per-activity detail pages remain
+> protected and are no longer reachable**. The pipeline is therefore
+> **single-pass**: the *Searcher Function* builds each `activity` directly from the
+> listing's `result-item` markup and dispatches a *Publisher* task itself. The
+> *Detail Scraper Function* is retained but **dormant** (fallback / manual
+> reprocessing).
+
 ### Search API
-The activities search endpoint from the Mountaineers website presents a single `GET` endpoint as follows:
+The approved listing page is a JS shell whose results load via an AJAX
+`@@faceted_query` endpoint:
 
 ```
-https://www.mountaineers.org/search/@@faceted_query?b_start:int=[start_index]&c8%5B%5D=[type]&type%5B%5D=mtneers.activity
+https://www.mountaineers.org/volunteer/volunteer-with-us/find-all-volunteer-activities/@@faceted_query?c4[]=[type]&b_start:int=[start_index]
 ```
 
-The `[start_index]` parameter is a zero-based record number to start the page of results at; pages are of length up to 20, with a page of fewer than 20 records indicating the end of the results.  The `[type]` parameter is one of the following activity types:
+Requirements for every request to this URL (and its paginated variants):
+
+- Send the header `mtn-approved-scraper: <value>`, where `<value>` comes from the
+  `MTN_SCRAPER_HEADER_VALUE` environment variable (low-sensitivity config with a
+  sensible default; never logged).
+  Without it, Cloudflare returns a `403 "Just a moment…"` challenge.
+- Send `Cache-Control: no-cache` **and** append a unique cache-buster query param
+  (e.g. `&_cb=<uuid>`). Responses are served through Varnish and a stale, often
+  empty, page is otherwise returned after a new activity is listed.
+- The retained `User-Agent` header is still sent.
+
+The activity-type facet on this page is `c4` (note: **not** `c8`, which the old
+global-search endpoint used) and its value uses spaces (e.g.
+`c4[]=Backcountry Skiing`). The `[start_index]` parameter is a zero-based record
+number; pages hold up to 20 records, and a `//nav[@class='pagination']//li[@class='next']/a/@href`
+link (already a `@@faceted_query` URL) or a page of fewer than 20 records indicates
+the end of results. The `[type]` parameter is one of the following activity types:
 
 - `Backcountry Skiing`
 
-Parameters should be encoded according to `application/x-www-form-urlencoded`.
+### Searcher Function: Single-Pass Listing Extraction
+The *Searcher Function* performs a search against the approved endpoint, builds a
+full `activity` (plus `leader`) from each `result-item`, stores new ones, and
+dispatches a *Publisher* task for each. Detail pages are not fetched.
 
-### Searcher Function: Activity Detail URLs from Search Results
-The *Searcher Function* is responsible for performing a search against the endpoint, extracting a list of activity detail URLs, and dispatching a *Detail Scraper* task for each new one.
+The endpoint returns an HTML document containing a list of activities. The
+documents [sample_faceted_query_response.html](tests/fixtures/sample_faceted_query_response.html),
+[sample_activity_search_response.html](tests/fixtures/sample_activity_search_response.html),
+and [sample_activity_search_response_1.html](tests/fixtures/sample_activity_search_response_1.html)
+contain example responses. Using XPath, each `//div[contains(@class,'result-item')]`
+element is a result; only rows whose permalink is under `/activities/activities/`
+are activities (the folder can also contain routes/places), and the following are
+extracted **relative to the item**:
 
-The search endpoint returns an HTML document containing a list of activities.  The document [sample_activity_search_response.html](tests/fixtures/sample_activity_search_response.html) contains an example response with no successive page of results, and the document [sample_activity_search_response_1.html](tests/fixtures/sample_activity_search_response_1.html) contains an example response with a successive page of results.
+- `.//h3[@class='result-title']/a/@href` — `activity_permalink` (the `document_id` is its final path segment).
+- `.//h3[@class='result-title']/a/text()` — `title`.
+- `.//div[@class='result-type']/text()` — `activity_type`; a trailing ` Trip` is stripped (e.g. "Backcountry Skiing Trip" → "Backcountry Skiing").
+- `.//div[@class='result-summary']/text()` — `description`.
+- `.//div[@class='result-difficulty']/text()` — `difficulty_rating` (strip the "Difficulty:" prefix; split on commas; normalize whitespace).
+- `.//div[@class='result-date']/text()` — `activity_date` (`%a, %b %d, %Y`; collapse internal whitespace first, since single-digit days render with a double space; for multi-day ranges use the start date; Pacific → UTC).
+- `.//div[@class='result-branch']/text()` — `branch`.
+- `.//div[@class='result-leader']//a/text()` and `.../@href` — `leader.name` and `leader.leader_permalink` (a direct `/members/<slug>`).
 
-Using XPath notation, each `//div[@class='result-item']` element in the response contains an activity.  Within an item, `.//h3[@class='result-title']/a/@href` is the URL of the activity detail page.
+The route/place **permalink** is only on the (unreachable) detail page, so `place`
+is left unset; the place **name** is recovered from the title (text after the first
+` - `) and stored as `place_name` (plain text). Rows missing a leader or a parseable
+date are skipped defensively.
 
 (*Pro Tip:* For validation of XPath expressions at the commandline, `xmllint --xpath` is super useful.)
 
-The Searcher Function should check the `activities` collection for a corresponding activity and enqueue one Detail Scraper task for each new activity detail URL.
+The Searcher Function checks the `activities` collection for each `document_id` and,
+for each new activity, creates the `leader` and `activity` documents and enqueues a
+*Publisher* task. If the response contains a next-page link, it enqueues a Searcher
+task for `start_index + 20`.
 
-In addition, if the search response contains `//nav[@class='pagination']//li[@class='next']/a/@href`, enqueue a Searcher task for that next page.
+### Detail Scraper Function: Data Binding and Extraction from Detail Pages (dormant)
+> **Dormant (issue #31).** Detail pages are Cloudflare-protected, so nothing
+> enqueues *Detail Scraper* tasks. The function and `scrape-queue` are retained as
+> a fallback / manual-reprocessing path and still produce a fully linkable `place`
+> if detail pages ever become reachable again.
 
-### Detail Scraper Function: Data Binding and Extraction from Detail Pages
 The *Detail Scraper Function* is responsible for extracting data from the activity detail page and binding it to the `activity` document, `leader` document, and `place` document, as necessary.  The URL passed into the function is the `activity_permalink`.
 
 The activity detail endpoint returns an HTML document with details of the activity.  The document [sample_activity_detail.html](tests/fixtures/sample_activity_detail.html) contains an example response.  Using XPath notation:

--- a/src/db/activities.py
+++ b/src/db/activities.py
@@ -32,9 +32,13 @@ def create_activity(activity: Activity, transaction=None) -> DocumentReference:
     doc_id = activity.document_id
     doc_ref = db.collection(COLLECTION_NAME).document(doc_id)
 
-    # Create references to leader and place
+    # Create references to leader and (optionally) place. Single-pass listing
+    # activities have no linkable place, only a plain-text place_name.
     leader_ref = db.collection('leaders').document(activity.leader.document_id)
-    place_ref = db.collection('places').document(activity.place.document_id)
+    place_ref = (
+        db.collection('places').document(activity.place.document_id)
+        if activity.place is not None else None
+    )
 
     # Build data dict
     # Note: discord_message_id is kept even when None so we can query for unpublished activities
@@ -46,6 +50,7 @@ def create_activity(activity: Activity, transaction=None) -> DocumentReference:
         'activity_date': activity.activity_date,
         'leader_ref': leader_ref,
         'place_ref': place_ref,
+        'place_name': activity.place_name,
         'activity_type': activity.activity_type,
         'branch': activity.branch,
         'discord_message_id': activity.discord_message_id,  # Always include, even if None
@@ -86,9 +91,12 @@ def update_activity(activity: Activity) -> DocumentReference:
     if not activity_exists(doc_id):
         raise ValueError(f"Activity {doc_id} does not exist")
 
-    # Create references to leader and place
+    # Create references to leader and (optionally) place.
     leader_ref = db.collection('leaders').document(activity.leader.document_id)
-    place_ref = db.collection('places').document(activity.place.document_id)
+    place_ref = (
+        db.collection('places').document(activity.place.document_id)
+        if activity.place is not None else None
+    )
 
     doc_ref = db.collection(COLLECTION_NAME).document(doc_id)
 
@@ -101,6 +109,7 @@ def update_activity(activity: Activity) -> DocumentReference:
         'activity_date': activity.activity_date,
         'leader_ref': leader_ref,
         'place_ref': place_ref,
+        'place_name': activity.place_name,
         'activity_type': activity.activity_type,
         'branch': activity.branch,
         'discord_message_id': activity.discord_message_id,
@@ -137,16 +146,22 @@ def get_activity(document_id: str) -> Optional[Activity]:
 
     data = doc.to_dict()
 
-    # Fetch referenced leader and place
+    # Fetch referenced leader (required).
     leader_ref = data['leader_ref']
-    place_ref = data['place_ref']
-
     leader = get_leader(leader_ref.id)
-    place = get_place(place_ref.id)
+    if not leader:
+        # Referenced document missing - should not happen
+        raise ValueError(f"Activity {document_id} has missing leader reference")
 
-    if not leader or not place:
-        # Referenced documents missing - should not happen
-        raise ValueError(f"Activity {document_id} has missing leader or place reference")
+    # Place is optional: single-pass listing activities have no place_ref, only
+    # a plain-text place_name.
+    place = None
+    place_ref = data.get('place_ref')
+    if place_ref is not None:
+        place = get_place(place_ref.id)
+        if not place:
+            # Referenced document missing - should not happen
+            raise ValueError(f"Activity {document_id} has missing place reference")
 
     return Activity(
         activity_permalink=data['activity_permalink'],
@@ -156,6 +171,7 @@ def get_activity(document_id: str) -> Optional[Activity]:
         activity_date=data['activity_date'],
         leader=leader,
         place=place,
+        place_name=data.get('place_name'),
         activity_type=data.get('activity_type'),
         branch=data.get('branch'),
         discord_message_id=data.get('discord_message_id'),

--- a/src/discord_client.py
+++ b/src/discord_client.py
@@ -152,8 +152,12 @@ def format_activity_message(activity: Activity) -> str:
 
     Format:
     📆 {{activity.activity_date in YYYY-MM-DD format in Pacific timezone}} {{emoji for activity.activity_type}} [{{activity.title}}]({{activity.activity_permalink}})
-    Leader: [{{activity.leader.name}}](<{{activity.leader.leader_permalink}}>) at [{{activity.place.name}}](<{{activity.place.place_permalink}}>)
+    Leader: [{{activity.leader.name}}](<{{activity.leader.leader_permalink}}>){{place clause}}
     Difficulty Ratings: {{comma-concatenated activity.difficulty_rating with optional emojis}}
+
+    The place clause is " at [{{place.name}}](<{{place.place_permalink}}>)" when a
+    linkable place is present, " at {{place_name}}" (plain text) for single-pass
+    listing activities, or omitted entirely when there is no place.
 
     Note: Using [text](<url>) prevents Discord from rendering link previews.
 
@@ -205,9 +209,19 @@ def format_activity_message(activity: Activity) -> str:
     # Format difficulty ratings with emojis
     difficulty_str = format_difficulty_ratings(activity.difficulty_rating)
 
+    # Format the place clause. A linkable place (from a detail-page scrape) is
+    # rendered as a hyperlink; a single-pass listing activity carries only a
+    # plain-text place_name; some activities have no place at all.
+    if activity.place is not None:
+        place_clause = f" at [{activity.place.name}](<{activity.place.place_permalink}>)"
+    elif activity.place_name:
+        place_clause = f" at {activity.place_name}"
+    else:
+        place_clause = ""
+
     # Format multi-line message
     line1 = f"📆 {date_str}{activity_emoji_str} [{activity.title}]({activity.activity_permalink})"
-    line2 = f"Leader: [{activity.leader.name}](<{activity.leader.leader_permalink}>) at [{activity.place.name}](<{activity.place.place_permalink}>)"
+    line2 = f"Leader: [{activity.leader.name}](<{activity.leader.leader_permalink}>){place_clause}"
     line3 = f"Difficulty Ratings: {difficulty_str}"
 
     message = f"{line1}\n{line2}\n{line3}"

--- a/src/functions/searcher.py
+++ b/src/functions/searcher.py
@@ -1,29 +1,45 @@
-"""Searcher Cloud Function - fetches search results and enqueues scraper tasks."""
+"""Searcher Cloud Function - single-pass listing scrape and publish enqueue.
+
+Detail pages remain Cloudflare-protected, so the searcher builds each Activity
+directly from the approved listing page (single-pass) and enqueues a publish
+task for every new activity. The detail scraper (``scraper.py`` / ``scrape-queue``)
+is kept dormant as a fallback / manual-reprocessing path. See issue #31.
+"""
 
 import logging
 from typing import Dict, Any
-from datetime import datetime, timezone
 
-from ..db import activity_exists, update_search_status
+from ..db import (
+    activity_exists,
+    create_activity,
+    create_or_update_leader,
+    create_or_update_place,
+    update_search_status,
+)
 from ..http_client import fetch_search_results
-from ..parsers import parse_search_results
-from ..tasks import enqueue_scrape_task, enqueue_search_task
+from ..parsers import parse_activity_listing
+from ..tasks import enqueue_publish_task, enqueue_search_task
 from ..config import is_processing_enabled
 
 
 logger = logging.getLogger(__name__)
 
+# Listing page size; pagination advances b_start by this amount.
+PAGE_SIZE = 20
+
 
 def searcher_handler(start_index: int = 0, activity_type: str = 'Backcountry Skiing') -> Dict[str, Any]:
     """
-    Handle a search task - fetch search results and enqueue scraper tasks.
+    Handle a search task - fetch the listing, store new activities, and enqueue
+    publish tasks.
 
     This function:
-    1. Fetches search results from the Mountaineers website
-    2. Extracts activity detail URLs
-    3. Checks if activity already exists in Firestore
-    4. Enqueues a scraper task for each NEW activity
-    5. If there's a next page, enqueues another search task
+    1. Fetches the approved listing page for the activity type / page.
+    2. Parses each result-item into a full Activity.
+    3. Skips activities that already exist in Firestore.
+    4. For each new activity: stores leader (+ place if present) and activity,
+       then enqueues a publish task.
+    5. If there's a next page, enqueues another search task.
 
     Args:
         start_index: Starting index for pagination.
@@ -31,18 +47,11 @@ def searcher_handler(start_index: int = 0, activity_type: str = 'Backcountry Ski
 
     Returns:
         Dict with:
-            - status: str - "success" or "error"
-            - activities_found: int - Number of activities found
-            - new_activities: int - Number of new activities enqueued
+            - status: str - "success", "skipped", or "error"
+            - activities_found: int - Number of activities parsed from the page
+            - new_activities: int - Number of new activities stored/enqueued
             - has_next_page: bool - Whether there's a next page
             - error: str (optional) - Error message if status is "error"
-
-    Example:
-        >>> result = searcher_handler(start_index=0)
-        >>> result['status']
-        'success'
-        >>> result['activities_found'] > 0
-        True
     """
     try:
         # Check if processing is enabled
@@ -55,43 +64,34 @@ def searcher_handler(start_index: int = 0, activity_type: str = 'Backcountry Ski
 
         logger.info(f"Searching for {activity_type} activities starting at index {start_index}")
 
-        # Fetch search results
+        # Fetch and parse the listing page
         html = fetch_search_results(start_index=start_index, activity_type=activity_type)
+        activities, next_page_url = parse_activity_listing(html)
 
-        # Parse search results
-        activity_urls, next_page_url = parse_search_results(html)
+        logger.info(f"Found {len(activities)} activities")
 
-
-        logger.info(f"Found {len(activity_urls)} activities")
-
-        # Enqueue scraper tasks for each NEW activity
         new_activities_count = 0
-        for url in activity_urls:
-            # Extract activity ID from URL
-            activity_id = url.rstrip('/').split('/')[-1]
+        for activity in activities:
+            activity_id = activity.document_id
 
-            # Check if activity already exists
+            # Skip activities we've already processed
             if activity_exists(activity_id):
                 logger.debug(f"Activity {activity_id} already exists, skipping")
                 continue
 
-            # Enqueue scraper task for new activity
             try:
-                enqueue_scrape_task(url)
-                logger.debug(f"Enqueued scraper task for: {url}")
+                _store_and_enqueue(activity)
                 new_activities_count += 1
             except Exception as e:
-                logger.error(f"Failed to enqueue scraper task for {url}: {e}")
+                logger.error(f"Failed to store/enqueue activity {activity_id}: {e}", exc_info=True)
 
-        logger.info(f"Enqueued {new_activities_count} new activities for scraping")
+        logger.info(f"Stored {new_activities_count} new activities")
 
         # If there's a next page, enqueue another search task
         if next_page_url:
-            logger.info(f"Next page found, enqueueing search task")
-            # Calculate next start index (increment by 20, the page size)
-            next_start_index = start_index + 20
+            logger.info("Next page found, enqueueing search task")
             try:
-                enqueue_search_task(next_start_index, activity_type)
+                enqueue_search_task(start_index + PAGE_SIZE, activity_type)
             except Exception as e:
                 logger.error(f"Failed to enqueue next search task: {e}")
 
@@ -100,7 +100,8 @@ def searcher_handler(start_index: int = 0, activity_type: str = 'Backcountry Ski
 
         return {
             'status': 'success',
-            'activities_found': len(activity_urls),
+            'activities_found': len(activities),
+            'new_activities': new_activities_count,
             'has_next_page': next_page_url is not None,
         }
 
@@ -115,3 +116,20 @@ def searcher_handler(start_index: int = 0, activity_type: str = 'Backcountry Ski
             'status': 'error',
             'error': error_message,
         }
+
+
+def _store_and_enqueue(activity) -> None:
+    """Store leader (+ place if present) and activity, then enqueue a publish
+    task. create_activity is idempotent, so a retry is safe."""
+    create_or_update_leader(activity.leader)
+    if activity.place is not None:
+        create_or_update_place(activity.place)
+
+    activity_ref = create_activity(activity)
+    activity_id = activity_ref.id
+    logger.info(f"Created activity {activity_id}")
+
+    # Enqueue publish task. If this fails, the activity is still stored and can
+    # be picked up by the catchup function.
+    enqueue_publish_task(activity_id)
+    logger.debug(f"Enqueued publish task for activity {activity_id}")

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -1,8 +1,13 @@
 """HTTP client for fetching Mountaineers website pages."""
 
 import os
+import uuid
+import logging
 import requests
-from typing import Optional
+from urllib.parse import urlencode
+
+
+logger = logging.getLogger(__name__)
 
 
 # Version is set via environment variable or defaults to "dev"
@@ -13,10 +18,32 @@ USER_AGENT = f'mounties-activities-discord-publisher/{VERSION}'
 # Default timeout for requests (in seconds)
 DEFAULT_TIMEOUT = 30
 
+# The Mountaineers has implemented Cloudflare scraper protection. A custom
+# bypass rule allows access to this specific listing URL (and its faceted-query
+# child path) when a custom header is present. See issue #31.
+APPROVED_URL = 'https://www.mountaineers.org/volunteer/volunteer-with-us/find-all-volunteer-activities'
+FACETED_QUERY_URL = f'{APPROVED_URL}/@@faceted_query'
+
+# Header that identifies us to the bypass rule. The value is sourced from the
+# environment (Secret Manager in production) and must never be logged. A default
+# is provided so the app works before the secret is wired up.
+SCRAPER_HEADER_NAME = 'mtn-approved-scraper'
+SCRAPER_HEADER_VALUE = os.environ.get('MTN_SCRAPER_HEADER_VALUE', 'MountaineersDevRequest')
+
+
+def _is_approved_url(url: str) -> bool:
+    """Return True if the URL is under the approved listing path (so the bypass
+    header, cache-control, and cache-buster should be applied)."""
+    return url.startswith(APPROVED_URL)
+
 
 def fetch_page(url: str, timeout: int = DEFAULT_TIMEOUT) -> str:
     """
     Fetch a web page with proper User-Agent header.
+
+    Requests under the approved listing URL automatically receive the
+    Cloudflare bypass header plus cache-busting (see issue #31); all other
+    requests are sent with just the User-Agent.
 
     Args:
         url: The URL to fetch
@@ -37,6 +64,16 @@ def fetch_page(url: str, timeout: int = DEFAULT_TIMEOUT) -> str:
         'User-Agent': USER_AGENT,
     }
 
+    if _is_approved_url(url):
+        # Attach the Cloudflare bypass header. Never log its value.
+        headers[SCRAPER_HEADER_NAME] = SCRAPER_HEADER_VALUE
+        # Responses are served through Varnish and a stale (often empty) page
+        # can be returned after a new activity is listed. Force a fresh copy
+        # with both no-cache and a unique cache-buster query param.
+        headers['Cache-Control'] = 'no-cache'
+        separator = '&' if '?' in url else '?'
+        url = f"{url}{separator}_cb={uuid.uuid4().hex}"
+
     response = requests.get(url, headers=headers, timeout=timeout)
     response.raise_for_status()
 
@@ -45,7 +82,10 @@ def fetch_page(url: str, timeout: int = DEFAULT_TIMEOUT) -> str:
 
 def fetch_search_results(start_index: int = 0, activity_type: str = 'Backcountry Skiing') -> str:
     """
-    Fetch search results from Mountaineers website.
+    Fetch activity listing results from the approved faceted-query endpoint.
+
+    The approved listing page itself is a JS shell; results load via this AJAX
+    endpoint. The activity-type facet on this page is ``c4`` (values use spaces).
 
     Args:
         start_index: Zero-based record number to start at (default: 0)
@@ -62,24 +102,16 @@ def fetch_search_results(start_index: int = 0, activity_type: str = 'Backcountry
         >>> 'result-item' in html
         True
     """
-    import logging
-    from urllib.parse import urlencode
-
-    logger = logging.getLogger(__name__)
-
-    base_url = 'https://www.mountaineers.org/search/@@faceted_query'
-
-    # Build query parameters
     params = {
+        'c4[]': activity_type,
         'b_start:int': start_index,
-        'c8[]': activity_type,
-        'type[]': 'mtneers.activity',
     }
 
-    # Construct full URL
-    url = f"{base_url}?{urlencode(params, safe='[]')}"
-    
-    logger.info(f"Fetching search results from: {url}")
+    # Keep '[]' and ':' literal so the URL matches the documented facet format
+    # (e.g. c4[]=Backcountry+Skiing&b_start:int=0).
+    url = f"{FACETED_QUERY_URL}?{urlencode(params, safe='[]:')}"
+
+    # Log the base URL without the cache-buster/header (added inside fetch_page).
+    logger.info(f"Fetching activity listing (start_index={start_index}, activity_type={activity_type})")
 
     return fetch_page(url)
-

--- a/src/models.py
+++ b/src/models.py
@@ -48,8 +48,12 @@ class Activity:
     description: str
     difficulty_rating: list[str]
     activity_date: datetime  # stored in UTC
-    place: Place
     leader: Leader
+    # place (with a linkable permalink) is only available from the detail page,
+    # which is Cloudflare-protected. Single-pass listing activities instead carry
+    # place_name (plain text, parsed from the title) with place left as None.
+    place: Optional[Place] = None
+    place_name: Optional[str] = None
     activity_type: Optional[str] = None
     branch: Optional[str] = None
     discord_message_id: Optional[str] = None

--- a/src/parsers/__init__.py
+++ b/src/parsers/__init__.py
@@ -2,10 +2,12 @@
 
 from .search_parser import parse_search_results, extract_activity_urls, extract_next_page_url
 from .detail_parser import parse_activity_detail
+from .listing_parser import parse_activity_listing
 
 __all__ = [
     'parse_search_results',
     'extract_activity_urls',
     'extract_next_page_url',
     'parse_activity_detail',
+    'parse_activity_listing',
 ]

--- a/src/parsers/detail_parser.py
+++ b/src/parsers/detail_parser.py
@@ -2,10 +2,9 @@
 
 from datetime import datetime
 from lxml import html
-import pytz
-from dateutil import parser as date_parser
 
 from ..models import Activity, Leader, Place
+from .helpers import parse_activity_date, parse_difficulty_rating
 
 
 def parse_activity_detail(html_content: str, activity_url: str) -> Activity:
@@ -105,24 +104,7 @@ def extract_activity_date(tree) -> datetime:
     if not date_nodes:
         raise ValueError("Could not find activity date")
 
-    date_str = date_nodes[0].strip()
-
-    # Handle multi-day activities (e.g. "Wed, Feb 11, 2026 — Thu, Feb 12, 2026")
-    # We only care about the start date
-    if "—" in date_str:
-        date_str = date_str.split("—")[0].strip()
-    elif "-" in date_str:
-        date_str = date_str.split("-")[0].strip()
-
-    # Parse the date (assumes Pacific time)
-    pacific = pytz.timezone('America/Los_Angeles')
-    naive_date = datetime.strptime(date_str, "%a, %b %d, %Y")
-
-    # Localize to Pacific time, then convert to UTC
-    pacific_date = pacific.localize(naive_date)
-    utc_date = pacific_date.astimezone(pytz.UTC)
-
-    return utc_date
+    return parse_activity_date(date_nodes[0])
 
 
 def extract_difficulty_rating(tree) -> list[str]:
@@ -137,18 +119,7 @@ def extract_difficulty_rating(tree) -> list[str]:
     if not text_nodes:
         return []
 
-    # Join all text nodes and strip
-    full_text = ''.join(text_nodes).strip()
-
-    # Remove "Difficulty:" prefix if present
-    if full_text.startswith("Difficulty:"):
-        full_text = full_text[len("Difficulty:"):].strip()
-
-    # Split by comma and clean each item
-    # Normalize whitespace: collapse sequences of whitespace to single spaces
-    ratings = [' '.join(r.split()) for r in full_text.split(',') if r.strip()]
-
-    return ratings
+    return parse_difficulty_rating(''.join(text_nodes))
 
 
 def extract_leader(tree) -> Leader:

--- a/src/parsers/helpers.py
+++ b/src/parsers/helpers.py
@@ -1,0 +1,77 @@
+"""Shared parsing helpers used by both the detail and listing parsers."""
+
+from datetime import datetime
+import pytz
+
+
+# Range separators used for multi-day activities. We only publish the start
+# date, so we split on the first one we find.
+_DATE_RANGE_SEPARATORS = ("—", "–", " - ")
+
+_PACIFIC = pytz.timezone('America/Los_Angeles')
+
+
+def parse_activity_date(date_str: str) -> datetime:
+    """
+    Parse an activity date string and convert from Pacific time to UTC.
+
+    Handles:
+      - Internal whitespace (single-digit days render as "Jul  3" with a double
+        space); collapsed before parsing.
+      - Multi-day activities (e.g. "Wed, Feb 11, 2026 — Thu, Feb 12, 2026"); the
+        start date is used.
+
+    Format: ``%a, %b %d, %Y`` (e.g., "Tue, Feb 10, 2026").
+
+    Args:
+        date_str: Raw date string extracted from the page.
+
+    Returns:
+        The start date as a timezone-aware UTC datetime.
+
+    Raises:
+        ValueError: If the string is empty or cannot be parsed.
+    """
+    if not date_str or not date_str.strip():
+        raise ValueError("Could not find activity date")
+
+    # Collapse all internal/leading/trailing whitespace to single spaces.
+    normalized = ' '.join(date_str.split())
+
+    # For multi-day activities, keep only the start date.
+    for separator in _DATE_RANGE_SEPARATORS:
+        if separator in normalized:
+            normalized = normalized.split(separator, 1)[0].strip()
+            break
+
+    naive_date = datetime.strptime(normalized, "%a, %b %d, %Y")
+
+    # Localize to Pacific time, then convert to UTC.
+    pacific_date = _PACIFIC.localize(naive_date)
+    return pacific_date.astimezone(pytz.UTC)
+
+
+def parse_difficulty_rating(text: str) -> list[str]:
+    """
+    Parse a difficulty string into a normalized list of ratings.
+
+    Strips an optional "Difficulty:" prefix, splits on commas, and collapses
+    internal whitespace within each rating.
+
+    Args:
+        text: Raw difficulty text (may include the "Difficulty:" label).
+
+    Returns:
+        List of difficulty ratings (empty if none).
+    """
+    if not text:
+        return []
+
+    full_text = text.strip()
+
+    # Remove "Difficulty:" prefix if present.
+    if full_text.startswith("Difficulty:"):
+        full_text = full_text[len("Difficulty:"):].strip()
+
+    # Split by comma and collapse whitespace within each rating.
+    return [' '.join(r.split()) for r in full_text.split(',') if r.strip()]

--- a/src/parsers/listing_parser.py
+++ b/src/parsers/listing_parser.py
@@ -1,0 +1,142 @@
+"""Parser for the Mountaineers approved activity-listing (faceted-query) page.
+
+Detail pages remain Cloudflare-protected, so everything we publish is built
+from the ``result-item`` markup on the listing itself (single-pass). See issue
+#31.
+"""
+
+import logging
+from typing import Optional
+
+from lxml import html
+
+from ..models import Activity, Leader
+from .helpers import parse_activity_date, parse_difficulty_rating
+
+
+logger = logging.getLogger(__name__)
+
+# Only rows whose permalink is under this path are real activities; the folder
+# can also contain routes/places and other content with result-title links.
+_ACTIVITY_PATH = '/activities/activities/'
+
+# The listing renders the activity type with a trailing " Trip"
+# (e.g. "Backcountry Skiing Trip"); the rest of the system keys on the bare
+# type ("Backcountry Skiing"), e.g. for the Discord emoji lookup.
+_TYPE_SUFFIX = ' Trip'
+
+
+def parse_activity_listing(html_content: str) -> tuple[list[Activity], Optional[str]]:
+    """
+    Parse a faceted-query listing page into activities and the next-page URL.
+
+    Args:
+        html_content: Raw HTML from the ``@@faceted_query`` endpoint.
+
+    Returns:
+        Tuple of (list of Activity, next page URL or None). Rows that are not
+        activities, or that are missing required fields, are skipped.
+    """
+    if not html_content or not html_content.strip():
+        return [], None
+
+    try:
+        tree = html.fromstring(html_content)
+    except Exception:
+        logger.warning("Could not parse listing HTML")
+        return [], None
+
+    activities = []
+    for item in tree.xpath("//div[contains(@class, 'result-item')]"):
+        activity = _parse_result_item(item)
+        if activity is not None:
+            activities.append(activity)
+
+    return activities, _extract_next_page_url(tree)
+
+
+def _clean(nodes) -> str:
+    """Join text nodes and collapse whitespace to single spaces."""
+    return ' '.join(''.join(nodes).split())
+
+
+def _parse_result_item(item) -> Optional[Activity]:
+    """Build an Activity from a single result-item, or None if it should be
+    skipped (non-activity row or missing required fields)."""
+    hrefs = item.xpath(".//h3[@class='result-title']/a/@href")
+    permalink = hrefs[0].strip() if hrefs else None
+
+    # Skip non-activity rows (routes/places, etc.).
+    if not permalink or _ACTIVITY_PATH not in permalink:
+        return None
+
+    title = _clean(item.xpath(".//h3[@class='result-title']/a/text()"))
+    if not title:
+        logger.warning(f"Skipping result-item with no title: {permalink}")
+        return None
+
+    # Leader is required; skip the row (rather than failing the whole page) if
+    # it is missing.
+    leader_names = item.xpath(".//div[@class='result-leader']//a/text()")
+    leader_hrefs = item.xpath(".//div[@class='result-leader']//a/@href")
+    if not leader_names or not leader_hrefs:
+        logger.warning(f"Skipping activity with no leader: {permalink}")
+        return None
+
+    # Date is required.
+    date_nodes = item.xpath(".//div[@class='result-date']/text()")
+    try:
+        activity_date = parse_activity_date(''.join(date_nodes))
+    except ValueError as e:
+        logger.warning(f"Skipping activity with unparseable date ({permalink}): {e}")
+        return None
+
+    leader = Leader(
+        leader_permalink=leader_hrefs[0].strip(),
+        name=leader_names[0].strip(),
+    )
+
+    return Activity(
+        activity_permalink=permalink,
+        title=title,
+        description=_clean(item.xpath(".//div[@class='result-summary']/text()")),
+        difficulty_rating=parse_difficulty_rating(''.join(item.xpath(".//div[@class='result-difficulty']/text()"))),
+        activity_date=activity_date,
+        place=None,
+        place_name=_place_name_from_title(title),
+        leader=leader,
+        activity_type=_normalize_activity_type(item.xpath(".//div[@class='result-type']/text()")),
+        branch=_clean(item.xpath(".//div[@class='result-branch']/text()")) or None,
+    )
+
+
+def _normalize_activity_type(nodes) -> Optional[str]:
+    """Clean the result-type text and strip a trailing ' Trip' so it matches the
+    bare type the rest of the system expects."""
+    activity_type = _clean(nodes)
+    if not activity_type:
+        return None
+    if activity_type.endswith(_TYPE_SUFFIX):
+        activity_type = activity_type[:-len(_TYPE_SUFFIX)].strip()
+    return activity_type or None
+
+
+def _place_name_from_title(title: str) -> Optional[str]:
+    """Recover the route/place name from the title (text after the first ' - ').
+
+    The place permalink is only on the (unreachable) detail page, so we keep the
+    name as plain text. Returns None when the title has no ' - ' separator.
+    """
+    if ' - ' not in title:
+        return None
+    name = title.split(' - ', 1)[1].strip()
+    return name or None
+
+
+def _extract_next_page_url(tree) -> Optional[str]:
+    """Extract the next-page URL from pagination, if present.
+
+    XPath: //nav[@class='pagination']//li[@class='next']/a/@href
+    """
+    next_urls = tree.xpath("//nav[@class='pagination']//li[@class='next']/a/@href")
+    return next_urls[0] if next_urls else None

--- a/tests/fixtures/sample_faceted_query_response.html
+++ b/tests/fixtures/sample_faceted_query_response.html
@@ -1,0 +1,93 @@
+<div id="search-results">
+  <div class="result-item contenttype-mtneers-activity">
+    <a class="result-left" href="https://www.mountaineers.org/activities/activities/backcountry-ski-snowboard-snoqualmie-summit-west-2-2025-12-09">
+      <img src="https://www.mountaineers.org/activities/activities/backcountry-ski-snowboard-snoqualmie-summit-west-2-2025-12-09/@@images/abc.jpeg" alt="x" />
+    </a>
+    <div class="result-center">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/activities/backcountry-ski-snowboard-snoqualmie-summit-west-2-2025-12-09">Backcountry Ski/Snowboard - Snoqualmie Summit West</a>
+      </h3>
+      <div class="result-type">
+        Backcountry Skiing Trip
+      </div>
+      <div class="result-summary">Tuesday night headlamp workout series for backcountry skiers / splitboarders.</div>
+      <div class="result-difficulty">
+        Difficulty: M1 Intermediate Ski
+      </div>
+      <div class="result-date">Tue, Dec  9, 2025</div>
+    </div>
+    <div class="result-sidebar">
+      <div class="result-branch">
+        Foothills Branch
+      </div>
+      <div class="result-leader">
+        <label>Leader:</label>
+        <a href="https://www.mountaineers.org/members/randolph-oakley">Randy Oakley</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="result-item contenttype-mtneers-activity">
+    <div class="result-center">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/activities/backcountry-ski-multi-day-2026-02-11">Backcountry Ski/Snowboard - Mount Baker Backcountry</a>
+      </h3>
+      <div class="result-type">
+        Backcountry Skiing Trip
+      </div>
+      <div class="result-summary">Multi-day ski tour.</div>
+      <div class="result-difficulty">
+        Difficulty: M2 Advanced Ski, M3G Advanced Glacier Ski
+      </div>
+      <div class="result-date">Wed, Feb 11, 2026 — Thu, Feb 12, 2026</div>
+    </div>
+    <div class="result-sidebar">
+      <div class="result-branch">
+        Seattle Branch
+      </div>
+      <div class="result-leader">
+        <label>Leader:</label>
+        <a href="https://www.mountaineers.org/members/jane-smith">Jane Smith</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="result-item contenttype-mtneers-activity">
+    <div class="result-center">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/activities/full-moon-ski-2026-03-01">Full Moon Ski</a>
+      </h3>
+      <div class="result-type">
+        Backcountry Skiing Trip
+      </div>
+      <div class="result-summary">No place in the title.</div>
+      <div class="result-difficulty">
+        Difficulty: M1 Intermediate Ski
+      </div>
+      <div class="result-date">Sun, Mar 1, 2026</div>
+    </div>
+    <div class="result-sidebar">
+      <div class="result-leader">
+        <label>Leader:</label>
+        <a href="https://www.mountaineers.org/members/john-doe">John Doe</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="result-item contenttype-mtneers-route">
+    <div class="result-center">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/routes-places/pinnacle-peak">Pinnacle Peak &amp; The Castle (Winter)</a>
+      </h3>
+      <div class="result-type">
+        Route/Place
+      </div>
+    </div>
+  </div>
+
+  <nav class="pagination">
+    <ul>
+      <li class="next"><a href="https://www.mountaineers.org/volunteer/volunteer-with-us/find-all-volunteer-activities/@@faceted_query?c4[]=Backcountry%20Skiing&amp;b_start:int=20">Next</a></li>
+    </ul>
+  </nav>
+</div>

--- a/tests/test_firestore_operations.py
+++ b/tests/test_firestore_operations.py
@@ -240,6 +240,43 @@ def test_get_activity(sample_activity):
     assert retrieved.place.document_id == "ski-resorts-nordic-centers_snoqualmie-summit-ski-areas"
 
 
+def test_create_and_get_placeless_activity(sample_leader):
+    """Single-pass activities have no place_ref, only a plain-text place_name.
+
+    Exercises the create write path (place_ref omitted) and the get_activity
+    read path (tolerates a missing place_ref) — the bug the issue #31 refined
+    plan called out, where the publisher would otherwise throw on placeless
+    activities.
+    """
+    create_or_update_leader(sample_leader)
+
+    activity = Activity(
+        activity_permalink="https://www.mountaineers.org/activities/activities/full-moon-ski-2026-03-01",
+        title="Full Moon Ski - Snoqualmie Summit West",
+        description="Single-pass listing activity.",
+        difficulty_rating=["M1 Intermediate Ski"],
+        activity_date=datetime(2026, 3, 1, 8, 0, 0, tzinfo=pytz.UTC),
+        leader=sample_leader,
+        place=None,
+        place_name="Snoqualmie Summit West",
+        activity_type="Backcountry Skiing",
+        branch="Foothills Branch",
+    )
+
+    create_activity(activity)
+
+    retrieved = get_activity("full-moon-ski-2026-03-01")
+
+    assert retrieved is not None
+    # No linkable place, but the plain-text name round-trips.
+    assert retrieved.place is None
+    assert retrieved.place_name == "Snoqualmie Summit West"
+    assert retrieved.branch == "Foothills Branch"
+    # Leader still populated.
+    assert retrieved.leader.name == "Randy Oakley"
+    assert retrieved.leader.document_id == "randolph-oakley"
+
+
 def test_get_nonexistent_activity():
     """Test retrieving a nonexistent activity."""
     retrieved = get_activity("nonexistent")

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,23 +2,48 @@
 
 import pytest
 from pathlib import Path
+from datetime import datetime
 from unittest.mock import MagicMock, call
+import pytz
 
 from src.functions import searcher_handler, scraper_handler
+from src.models import Activity, Leader
 
 
-@pytest.fixture
-def search_response_html():
-    """Load sample search response HTML."""
-    fixture_path = Path(__file__).parent / "fixtures" / "sample_activity_search_response.html"
-    return fixture_path.read_text()
+def _make_activity(slug: str) -> Activity:
+    """Build a minimal single-pass (place-less) Activity for searcher tests."""
+    return Activity(
+        activity_permalink=f"https://www.mountaineers.org/activities/activities/{slug}",
+        title="Backcountry Ski/Snowboard - Somewhere",
+        description="desc",
+        difficulty_rating=["M1 Intermediate Ski"],
+        activity_date=datetime(2026, 2, 10, 8, 0, 0, tzinfo=pytz.UTC),
+        leader=Leader(leader_permalink="https://www.mountaineers.org/members/x", name="X"),
+        place_name="Somewhere",
+        activity_type="Backcountry Skiing",
+    )
 
 
-@pytest.fixture
-def search_response_with_next_html():
-    """Load sample search response with next page."""
-    fixture_path = Path(__file__).parent / "fixtures" / "sample_activity_search_response_1.html"
-    return fixture_path.read_text()
+def _mock_searcher_deps(mocker, activities, next_page_url=None):
+    """Patch the searcher's fetch/parse/db/enqueue dependencies. Returns a dict
+    of the mocks for assertions."""
+    mocker.patch('src.functions.searcher.is_processing_enabled', return_value=True)
+    mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results', return_value='<html></html>')
+    mock_parse = mocker.patch('src.functions.searcher.parse_activity_listing',
+                              return_value=(activities, next_page_url))
+    mocker.patch('src.functions.searcher.create_or_update_leader')
+    mock_create = mocker.patch('src.functions.searcher.create_activity')
+    mock_create.return_value = MagicMock(id='some-id')
+    mocker.patch('src.functions.searcher.update_search_status')
+    mock_publish = mocker.patch('src.functions.searcher.enqueue_publish_task')
+    mock_search = mocker.patch('src.functions.searcher.enqueue_search_task')
+    return {
+        'fetch': mock_fetch,
+        'parse': mock_parse,
+        'create_activity': mock_create,
+        'enqueue_publish': mock_publish,
+        'enqueue_search': mock_search,
+    }
 
 
 @pytest.fixture
@@ -28,172 +53,110 @@ def activity_detail_html():
     return fixture_path.read_text()
 
 
-# Searcher Function Tests
+# Searcher Function Tests (single-pass)
 
-def test_searcher_handler_success(mocker, search_response_html):
-    """Test successful search with no next page."""
-    # Mock fetch_search_results
-    mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results')
-    mock_fetch.return_value = search_response_html
+def test_searcher_handler_success(mocker):
+    """Single-pass: all new activities are stored and publish tasks enqueued."""
+    activities = [_make_activity(f"activity-{i}") for i in range(3)]
+    mocks = _mock_searcher_deps(mocker, activities, next_page_url=None)
+    mocker.patch('src.functions.searcher.activity_exists', return_value=False)
 
-    # Mock activity_exists to always return False (all new activities)
-    mock_activity_exists = mocker.patch('src.functions.searcher.activity_exists')
-    mock_activity_exists.return_value = False
-
-    # Mock enqueue functions
-    mock_enqueue_scrape = mocker.patch('src.functions.searcher.enqueue_scrape_task')
-    mock_enqueue_search = mocker.patch('src.functions.searcher.enqueue_search_task')
-
-    # Call handler
     result = searcher_handler(start_index=0)
 
-    # Verify result
     assert result['status'] == 'success'
-    assert result['activities_found'] == 14
+    assert result['activities_found'] == 3
+    assert result['new_activities'] == 3
     assert result['has_next_page'] is False
 
-    # Verify fetch was called correctly
-    mock_fetch.assert_called_once_with(start_index=0, activity_type='Backcountry Skiing')
-
-    # Verify scraper tasks were enqueued for each activity
-    assert mock_enqueue_scrape.call_count == 14
-
-    # Verify no next search task was enqueued (no next page)
-    mock_enqueue_search.assert_not_called()
+    mocks['fetch'].assert_called_once_with(start_index=0, activity_type='Backcountry Skiing')
+    # Single-pass: publish tasks enqueued directly, no detail fetch/scrape.
+    assert mocks['enqueue_publish'].call_count == 3
+    assert mocks['create_activity'].call_count == 3
+    mocks['enqueue_search'].assert_not_called()
 
 
-def test_searcher_handler_with_next_page(mocker, search_response_with_next_html):
-    """Test search with next page."""
-    # Mock fetch_search_results
-    mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results')
-    mock_fetch.return_value = search_response_with_next_html
+def test_searcher_handler_with_next_page(mocker):
+    """A next-page URL triggers another search task at start_index + 20."""
+    activities = [_make_activity(f"activity-{i}") for i in range(2)]
+    mocks = _mock_searcher_deps(mocker, activities, next_page_url='https://example/@@faceted_query?b_start:int=20')
+    mocker.patch('src.functions.searcher.activity_exists', return_value=False)
 
-    # Mock activity_exists to always return False
-    mock_activity_exists = mocker.patch('src.functions.searcher.activity_exists')
-    mock_activity_exists.return_value = False
-
-    # Mock enqueue functions
-    mock_enqueue_scrape = mocker.patch('src.functions.searcher.enqueue_scrape_task')
-    mock_enqueue_search = mocker.patch('src.functions.searcher.enqueue_search_task')
-
-    # Call handler
     result = searcher_handler(start_index=0)
 
-    # Verify result
     assert result['status'] == 'success'
-    assert result['activities_found'] == 20
     assert result['has_next_page'] is True
-
-    # Verify scraper tasks were enqueued for each activity
-    assert mock_enqueue_scrape.call_count == 20
-
-    # Verify next search task was enqueued
-    mock_enqueue_search.assert_called_once_with(20, 'Backcountry Skiing')
+    mocks['enqueue_search'].assert_called_once_with(20, 'Backcountry Skiing')
 
 
-def test_searcher_handler_custom_activity_type(mocker, search_response_html):
-    """Test search with custom activity type."""
-    # Mock fetch_search_results
-    mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results')
-    mock_fetch.return_value = search_response_html
+def test_searcher_handler_custom_activity_type(mocker):
+    """Custom activity type is threaded through fetch and next-page enqueue."""
+    mocks = _mock_searcher_deps(mocker, [_make_activity("a-0")],
+                                next_page_url='https://example/@@faceted_query?b_start:int=20')
+    mocker.patch('src.functions.searcher.activity_exists', return_value=False)
 
-    # Mock activity_exists to always return False
-    mock_activity_exists = mocker.patch('src.functions.searcher.activity_exists')
-    mock_activity_exists.return_value = False
-
-    # Mock enqueue functions
-    mocker.patch('src.functions.searcher.enqueue_scrape_task')
-    mocker.patch('src.functions.searcher.enqueue_search_task')
-
-    # Call handler with custom activity type
     result = searcher_handler(start_index=0, activity_type='Rock Climbing')
 
-    # Verify fetch was called with custom activity type
-    mock_fetch.assert_called_once_with(start_index=0, activity_type='Rock Climbing')
-
+    mocks['fetch'].assert_called_once_with(start_index=0, activity_type='Rock Climbing')
+    mocks['enqueue_search'].assert_called_once_with(20, 'Rock Climbing')
     assert result['status'] == 'success'
 
 
 def test_searcher_handler_http_error(mocker):
     """Test searcher handling HTTP error."""
-    # Mock fetch to raise an exception
+    mocker.patch('src.functions.searcher.is_processing_enabled', return_value=True)
+    mocker.patch('src.functions.searcher.update_search_status')
     mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results')
     mock_fetch.side_effect = Exception('Network error')
 
-    # Call handler
     result = searcher_handler(start_index=0)
 
-    # Verify error response
     assert result['status'] == 'error'
     assert 'error' in result
     assert 'Network error' in result['error']
 
 
-def test_searcher_handler_continues_on_enqueue_failure(mocker, search_response_html):
-    """Test that searcher continues even if some enqueue operations fail."""
-    # Mock fetch_search_results
-    mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results')
-    mock_fetch.return_value = search_response_html
+def test_searcher_handler_continues_on_store_failure(mocker):
+    """A failure storing one activity does not abort the whole page."""
+    activities = [_make_activity(f"activity-{i}") for i in range(3)]
+    mocks = _mock_searcher_deps(mocker, activities, next_page_url=None)
+    mocker.patch('src.functions.searcher.activity_exists', return_value=False)
+    # Second activity's publish enqueue fails.
+    mocks['enqueue_publish'].side_effect = [None, Exception('enqueue failed'), None]
 
-    # Mock activity_exists to always return False
-    mock_activity_exists = mocker.patch('src.functions.searcher.activity_exists')
-    mock_activity_exists.return_value = False
-
-    # Mock enqueue to fail on some calls
-    mock_enqueue_scrape = mocker.patch('src.functions.searcher.enqueue_scrape_task')
-    mock_enqueue_scrape.side_effect = [
-        None,  # First succeeds
-        Exception('Task enqueue failed'),  # Second fails
-        None,  # Rest succeed
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    ]
-
-    # Call handler
     result = searcher_handler(start_index=0)
 
-    # Should still return success
     assert result['status'] == 'success'
-    assert result['activities_found'] == 14
+    assert result['activities_found'] == 3
+    # Two succeeded, one failed mid-store.
+    assert result['new_activities'] == 2
 
 
-def test_searcher_handler_skips_existing_activities(mocker, search_response_html):
-    """Test that searcher skips activities that already exist in Firestore."""
-    # Mock fetch_search_results
-    mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results')
-    mock_fetch.return_value = search_response_html
+def test_searcher_handler_skips_existing_activities(mocker):
+    """Activities already in Firestore are skipped (dedup)."""
+    activities = [_make_activity(f"activity-{i}") for i in range(5)]
+    mocks = _mock_searcher_deps(mocker, activities, next_page_url=None)
+    # First 2 already exist, last 3 are new.
+    mock_exists = mocker.patch('src.functions.searcher.activity_exists',
+                               side_effect=[True, True, False, False, False])
 
-    # Mock activity_exists
-    mock_activity_exists = mocker.patch('src.functions.searcher.activity_exists')
-    # Make it return True for the first activity, False for others
-    # The sample HTML has 14 activities
-    # We'll say the first 5 exist
-    mock_activity_exists.side_effect = [True] * 5 + [False] * 9
-
-    # Mock enqueue functions
-    mock_enqueue_scrape = mocker.patch('src.functions.searcher.enqueue_scrape_task')
-    mock_enqueue_search = mocker.patch('src.functions.searcher.enqueue_search_task')
-
-    # Call handler
     result = searcher_handler(start_index=0)
 
-    # Verify result
     assert result['status'] == 'success'
-    assert result['activities_found'] == 14
-    # Should have enqueued only 9 tasks (14 found - 5 existing)
-    assert mock_enqueue_scrape.call_count == 9
+    assert result['activities_found'] == 5
+    assert result['new_activities'] == 3
+    assert mocks['enqueue_publish'].call_count == 3
+    assert mock_exists.call_count == 5
 
-    # Verify activity_exists was called for each activity
-    assert mock_activity_exists.call_count == 14
+
+def test_searcher_handler_skipped_when_processing_disabled(mocker):
+    """When processing is disabled the searcher does no work."""
+    mocker.patch('src.functions.searcher.is_processing_enabled', return_value=False)
+    mock_fetch = mocker.patch('src.functions.searcher.fetch_search_results')
+
+    result = searcher_handler(start_index=0)
+
+    assert result['status'] == 'skipped'
+    mock_fetch.assert_not_called()
 
 
 # Scraper Function Tests

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,86 @@
+"""Tests for the HTTP client (approved URL, bypass header, cache-busting)."""
+
+import re
+import pytest
+
+from src import http_client
+from src.http_client import (
+    fetch_page,
+    fetch_search_results,
+    APPROVED_URL,
+    FACETED_QUERY_URL,
+    SCRAPER_HEADER_NAME,
+    SCRAPER_HEADER_VALUE,
+    USER_AGENT,
+)
+
+
+class _FakeResponse:
+    def __init__(self, text='<html></html>'):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+@pytest.fixture
+def captured_get(mocker):
+    """Patch requests.get and capture the (url, headers) it was called with."""
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append({'url': url, 'headers': headers or {}, 'timeout': timeout})
+        return _FakeResponse()
+
+    mocker.patch('src.http_client.requests.get', side_effect=fake_get)
+    return calls
+
+
+def test_approved_url_gets_bypass_header_and_cache_bust(captured_get):
+    fetch_page(FACETED_QUERY_URL + '?c4[]=Backcountry Skiing&b_start:int=0')
+
+    call = captured_get[0]
+    assert call['headers'][SCRAPER_HEADER_NAME] == SCRAPER_HEADER_VALUE
+    assert call['headers']['Cache-Control'] == 'no-cache'
+    assert call['headers']['User-Agent'] == USER_AGENT
+    # Cache-buster appended (the request already had a query string).
+    assert re.search(r'&_cb=[0-9a-f]+$', call['url'])
+
+
+def test_paginated_approved_url_also_gets_header(captured_get):
+    """A next-page @@faceted_query URL is still under the approved path."""
+    fetch_page(FACETED_QUERY_URL + '?c4[]=Backcountry Skiing&b_start:int=20')
+    assert SCRAPER_HEADER_NAME in captured_get[0]['headers']
+
+
+def test_cache_buster_uses_question_mark_when_no_query(captured_get):
+    fetch_page(APPROVED_URL)
+    assert re.search(r'\?_cb=[0-9a-f]+$', captured_get[0]['url'])
+
+
+def test_other_urls_do_not_get_bypass_header(captured_get):
+    fetch_page('https://www.mountaineers.org/activities/activities/some-activity')
+
+    call = captured_get[0]
+    assert SCRAPER_HEADER_NAME not in call['headers']
+    assert 'Cache-Control' not in call['headers']
+    assert call['headers']['User-Agent'] == USER_AGENT
+    # No cache-buster on non-approved URLs.
+    assert '_cb=' not in call['url']
+
+
+def test_cache_buster_is_unique_per_request(captured_get):
+    fetch_page(APPROVED_URL)
+    fetch_page(APPROVED_URL)
+    assert captured_get[0]['url'] != captured_get[1]['url']
+
+
+def test_fetch_search_results_builds_c4_faceted_query(captured_get):
+    fetch_search_results(start_index=40, activity_type='Backcountry Skiing')
+
+    url = captured_get[0]['url']
+    assert url.startswith(FACETED_QUERY_URL + '?')
+    assert 'c4[]=Backcountry' in url
+    assert 'b_start:int=40' in url
+    # Header applied because it's the approved endpoint.
+    assert SCRAPER_HEADER_NAME in captured_get[0]['headers']

--- a/tests/test_listing_parser.py
+++ b/tests/test_listing_parser.py
@@ -1,0 +1,158 @@
+"""Tests for the single-pass listing parser."""
+
+import pytest
+from pathlib import Path
+
+from src.parsers.listing_parser import parse_activity_listing
+
+
+@pytest.fixture
+def faceted_query_html():
+    """Load the sample @@faceted_query listing response."""
+    fixture_path = Path(__file__).parent / "fixtures" / "sample_faceted_query_response.html"
+    return fixture_path.read_text()
+
+
+@pytest.fixture
+def activities(faceted_query_html):
+    acts, _ = parse_activity_listing(faceted_query_html)
+    return acts
+
+
+def test_skips_non_activity_rows(activities):
+    """The Route/Place row must be skipped; only the 3 activities remain."""
+    assert len(activities) == 3
+    for a in activities:
+        assert '/activities/activities/' in a.activity_permalink
+
+
+def test_extracts_next_page_url(faceted_query_html):
+    _, next_url = parse_activity_listing(faceted_query_html)
+    assert next_url is not None
+    assert '@@faceted_query' in next_url
+    assert 'b_start:int=20' in next_url
+
+
+def test_full_field_extraction(activities):
+    a = activities[0]
+    assert a.document_id == 'backcountry-ski-snowboard-snoqualmie-summit-west-2-2025-12-09'
+    assert a.title == 'Backcountry Ski/Snowboard - Snoqualmie Summit West'
+    assert a.description.startswith('Tuesday night headlamp')
+    assert a.difficulty_rating == ['M1 Intermediate Ski']
+    assert a.branch == 'Foothills Branch'
+    assert a.leader.name == 'Randy Oakley'
+    assert a.leader.leader_permalink == 'https://www.mountaineers.org/members/randolph-oakley'
+    assert a.leader.document_id == 'randolph-oakley'
+
+
+def test_activity_type_strips_trip_suffix(activities):
+    """'Backcountry Skiing Trip' -> 'Backcountry Skiing' so the emoji lookup works."""
+    assert activities[0].activity_type == 'Backcountry Skiing'
+
+
+def test_place_name_from_title(activities):
+    """Place name is the text after the first ' - ', place object stays None."""
+    assert activities[0].place is None
+    assert activities[0].place_name == 'Snoqualmie Summit West'
+    assert activities[1].place_name == 'Mount Baker Backcountry'
+
+
+def test_missing_place_in_title(activities):
+    """Titles with no ' - ' separator yield place_name None."""
+    full_moon = activities[2]
+    assert full_moon.title == 'Full Moon Ski'
+    assert full_moon.place_name is None
+    assert full_moon.place is None
+
+
+def test_single_digit_day_date(activities):
+    """'Tue, Dec  9, 2025' (double space) parses; Dec is PST -> 08:00 UTC."""
+    d = activities[0].activity_date
+    assert (d.year, d.month, d.day, d.hour) == (2025, 12, 9, 8)
+
+
+def test_multi_day_uses_start_date(activities):
+    """Multi-day 'Feb 11 — Feb 12' uses the start date."""
+    d = activities[1].activity_date
+    assert (d.year, d.month, d.day, d.hour) == (2026, 2, 11, 8)
+
+
+def test_multiple_difficulties(activities):
+    assert activities[1].difficulty_rating == ['M2 Advanced Ski', 'M3G Advanced Glacier Ski']
+
+
+def test_branch_optional(activities):
+    """Item 3 has no result-branch."""
+    assert activities[2].branch is None
+
+
+def test_no_pagination_yields_none():
+    """Activities present but no pagination nav -> next_url is None."""
+    html = """
+    <div class="result-item">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/activities/solo-2026-01-01">Solo Ski - Somewhere</a>
+      </h3>
+      <div class="result-date">Thu, Jan 1, 2026</div>
+      <div class="result-leader"><a href="https://www.mountaineers.org/members/x">X</a></div>
+    </div>
+    """
+    activities, next_url = parse_activity_listing(html)
+    assert len(activities) == 1
+    assert next_url is None
+
+
+def test_place_name_with_multiple_hyphens():
+    """Only the first ' - ' splits title from place; the rest stays in the name."""
+    html = """
+    <div class="result-item">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/activities/multi-2026-01-01">Backcountry Ski - Mount Baker - North Ridge</a>
+      </h3>
+      <div class="result-date">Thu, Jan 1, 2026</div>
+      <div class="result-leader"><a href="https://www.mountaineers.org/members/x">X</a></div>
+    </div>
+    """
+    activities, _ = parse_activity_listing(html)
+    assert len(activities) == 1
+    assert activities[0].place_name == "Mount Baker - North Ridge"
+
+
+def test_empty_html():
+    assert parse_activity_listing('') == ([], None)
+    assert parse_activity_listing('   ') == ([], None)
+
+
+def test_garbage_html():
+    activities, next_url = parse_activity_listing('not really <<< html')
+    assert activities == []
+    assert next_url is None
+
+
+def test_skips_activity_missing_leader():
+    """A row with no leader is skipped rather than failing the whole page."""
+    html = """
+    <div class="result-item">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/activities/no-leader-2026-01-01">No Leader - Somewhere</a>
+      </h3>
+      <div class="result-date">Thu, Jan 1, 2026</div>
+    </div>
+    """
+    activities, _ = parse_activity_listing(html)
+    assert activities == []
+
+
+def test_skips_activity_with_bad_date():
+    """A row with an unparseable date is skipped."""
+    html = """
+    <div class="result-item">
+      <h3 class="result-title">
+        <a href="https://www.mountaineers.org/activities/activities/bad-date">Bad Date - Somewhere</a>
+      </h3>
+      <div class="result-date">sometime next week</div>
+      <div class="result-leader"><a href="https://www.mountaineers.org/members/x">X</a></div>
+    </div>
+    """
+    activities, _ = parse_activity_listing(html)
+    assert activities == []

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -68,6 +68,46 @@ def test_format_activity_message(sample_activity):
     assert 'Difficulty Ratings: 🟢 M1 Intermediate Ski' in message
 
 
+def test_format_activity_message_plain_text_place(sample_leader):
+    """Single-pass activities render place_name as plain text (no link)."""
+    activity = Activity(
+        activity_permalink="https://www.mountaineers.org/activities/activities/x-2026-02-10",
+        title="Backcountry Ski/Snowboard - Snoqualmie Summit West",
+        description="desc",
+        difficulty_rating=["M1 Intermediate Ski"],
+        activity_date=datetime(2026, 2, 10, 8, 0, 0, tzinfo=pytz.UTC),
+        leader=sample_leader,
+        place=None,
+        place_name="Snoqualmie Summit West",
+    )
+
+    message = format_activity_message(activity)
+
+    assert 'Leader: [Randy Oakley](<https://www.mountaineers.org/members/randy-oakley>) at Snoqualmie Summit West' in message
+    # No markdown link for the place.
+    assert 'at [Snoqualmie Summit West]' not in message
+
+
+def test_format_activity_message_no_place(sample_leader):
+    """Activities with neither place nor place_name omit the 'at ...' clause."""
+    activity = Activity(
+        activity_permalink="https://www.mountaineers.org/activities/activities/x-2026-02-10",
+        title="Full Moon Ski",
+        description="desc",
+        difficulty_rating=["M1 Intermediate Ski"],
+        activity_date=datetime(2026, 2, 10, 8, 0, 0, tzinfo=pytz.UTC),
+        leader=sample_leader,
+        place=None,
+        place_name=None,
+    )
+
+    message = format_activity_message(activity)
+
+    lines = message.split('\n')
+    assert lines[1] == 'Leader: [Randy Oakley](<https://www.mountaineers.org/members/randy-oakley>)'
+    assert ' at ' not in lines[1]
+
+
 def test_format_activity_message_date_conversion():
     """Test that UTC date is correctly converted to Pacific time."""
     leader = Leader(


### PR DESCRIPTION
Closes #31.

## Summary
The Mountaineers implemented Cloudflare protection and gave us a single **approved** listing URL reachable via a bypass header. Per-activity **detail pages remain protected**, so this converts the pipeline from two-pass (search → fetch each detail page → publish) to **single-pass**: the searcher builds each activity directly from the listing's `result-item` markup and enqueues a publish task itself. The detail scraper and `scrape-queue` are retained but **dormant** as a fallback / manual-reprocessing path (one-flag revert).

## Key changes
- **http_client** — approved `@@faceted_query` URL with the `c4` facet; attaches `mtn-approved-scraper` (from `MTN_SCRAPER_HEADER_VALUE`, never logged), `Cache-Control: no-cache`, and a unique cache-buster on approved-URL requests to defeat stale Varnish responses.
- **parsers** — new `listing_parser.py` (full `Activity` per `result-item`, incl. `branch` and `place_name` from title); shared date/difficulty helpers factored out into `helpers.py`.
- **models/db** — `place` is now optional; new plain-text `place_name`. Write path omits `place_ref` when absent; `get_activity` tolerates a missing `place_ref` (fixes the publisher throwing on placeless activities).
- **searcher** — single-pass: fetch → parse → dedup → store leader+activity → enqueue publish.
- **discord_client** — place rendered as link / plain text / omitted.
- **deploy/config** — `MTN_SCRAPER_HEADER_VALUE` env on searcher; `scrape-queue` marked dormant.
- **docs** — spec.md, ARCHITECTURE.txt, architecture.puml, README.md, OPERATIONS.md, ENVIRONMENTS.md updated.

## Route/Place decision
The place permalink lived only on the (now unreachable) detail page. Per discussion on #31, we keep the place **name** (parsed from the title) as **plain text** in the Discord message; `place` is optional and unset for single-pass activities.

## Testing
- New/updated unit tests: `test_listing_parser.py`, `test_http_client.py`, single-pass `test_functions.py` searcher tests, place-optional Discord tests, and a placeless Firestore round-trip.
- 43 fully-mocked unit tests pass locally; parser validated against the real captured search fixture (20 activities). Firestore-backed tests require the emulator (not run locally) — please confirm green in CI.
- A Fable pre-check-in review found no correctness bugs; its doc/cleanup/test-coverage findings were applied.

## Notes for review / deployment
- Hard to assess end-to-end out of the box since there are currently no listed activities; dummy data can exercise the flow once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)