### PR TITLE
Wire MTN_SCRAPER_HEADER_VALUE into Pulumi searcher (Issue #31)

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -7,6 +7,9 @@ config = pulumi.Config()
 project = gcp.config.project
 region = gcp.config.region or "us-central1"
 deploy_env = os.environ.get("DEPLOY_ENV", "prod")
+# Cloudflare bypass header value for the approved scraping URL (issue #31).
+# Low-sensitivity config (published in the issue); overridable via env.
+mtn_scraper_header_value = os.environ.get("MTN_SCRAPER_HEADER_VALUE", "MountaineersDevRequest")
 # Load secrets from files
 def read_secret_file(filename):
     try:
@@ -199,6 +202,8 @@ searcher = gcp.cloudfunctionsv2.Function("searcher",
             "GCP_PROJECT": project,
             "GCP_LOCATION": region,
             "DEPLOY_ENV": deploy_env,
+            # Searcher fetches the approved listing and needs the bypass header.
+            "MTN_SCRAPER_HEADER_VALUE": mtn_scraper_header_value,
         }
     )
 )


### PR DESCRIPTION
Follow-up to #32.

## Why
#32 added `MTN_SCRAPER_HEADER_VALUE` to `deploy.sh`, but the actual deploy path is **Pulumi** (`infrastructure/__main__.py`), where the searcher's environment did not set it. The code defaults to the correct value (`MountaineersDevRequest`), so **behavior is unchanged** — this just makes the header value configurable via env on the real deploy path, mirroring `deploy.sh`.

## Change
- Read `MTN_SCRAPER_HEADER_VALUE` from env (default `MountaineersDevRequest`) alongside `DEPLOY_ENV`.
- Set it in the **searcher** function's `environment_variables`. Only the searcher fetches the approved listing; the dormant scraper fetches detail URLs outside the approved path, so it doesn't need the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)