### PR TITLE
Use a project-local virtualenv for the Pulumi program (Issue #31)

### DIFF
--- a/infrastructure/Pulumi.yaml
+++ b/infrastructure/Pulumi.yaml
@@ -1,3 +1,9 @@
 name: mounties-activity-publisher
-runtime: python
+runtime:
+  name: python
+  options:
+    # Use a project-local virtualenv (infrastructure/venv, gitignored) so the
+    # Pulumi program's deps are isolated instead of installed into system python.
+    # Create it with: pulumi install  (or: uv venv venv && uv pip install -r requirements.txt)
+    virtualenv: venv
 description: Infrastructure for Mountaineers Activities Discord Publisher


### PR DESCRIPTION
Follow-up to #31 deploy tooling. Reintroduces, via PR, a change that was briefly pushed directly to `main` and then reverted (commit `20255d8` → revert `7828550`).

## Why
`infrastructure/Pulumi.yaml` declared `runtime: python` with no virtualenv, so Pulumi used the ambient system `python3` and prompted for a global `pip install` of `pulumi` / `pulumi-gcp`. This switches to a **project-local, gitignored** virtualenv.

## Change
- `runtime.options.virtualenv: venv` in `Pulumi.yaml`.
- Create the venv with `pulumi install` (or `uv venv venv && uv pip install -r requirements.txt`). `infrastructure/venv/` is already covered by `.gitignore`.

## Notes
- Verified locally: the venv resolves `pulumi` + `pulumi-gcp 9.29.0`, and every `gcp.*` symbol `__main__.py` uses resolves under that version.
- Heads-up (not part of this PR): `requirements.txt` is unpinned (`pulumi-gcp>=7.0.0`), so a fresh install now pulls provider **9.x**. The first `pulumi preview` after this may show provider-upgrade diffs vs. the last-deployed state — worth reviewing before `pulumi up`. Happy to pin the provider in a separate PR if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)