### PR TITLE
Pin Pulumi provider versions (Issue #31)

### DIFF
--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,2 +1,6 @@
-pulumi>=3.0.0
-pulumi-gcp>=7.0.0
+# Pinned to avoid surprise major-version upgrades (issue #31). pulumi-gcp is
+# capped to the verified 9.x line; the pulumi SDK is capped to its 3.x major to
+# stay compatible with the CLI. Bump deliberately after reviewing a pulumi
+# preview for provider-driven diffs.
+pulumi>=3.0.0,<4.0.0
+pulumi-gcp>=9.29.0,<10.0.0


### PR DESCRIPTION
Deploy-tooling hardening for #31. Independent of #34 (touches only `infrastructure/requirements.txt`).

## Why
`requirements.txt` was unpinned (`pulumi>=3.0.0`, `pulumi-gcp>=7.0.0`), so a fresh install resolves to the latest provider major (currently **9.x**) — exactly the kind of surprise bump that just broke the local Pulumi environment.

## Change
```
pulumi>=3.0.0,<4.0.0
pulumi-gcp>=9.29.0,<10.0.0
```
- Caps `pulumi-gcp` to the verified **9.x** line (floor at 9.29.0, the version currently installed and validated).
- Caps the `pulumi` SDK to its **3.x** major for CLI compatibility.

## Verification
- Constraints resolve to `pulumi 3.251.0` / `pulumi-gcp 9.29.0` in the project-local venv.
- Every `gcp.*` symbol used by `infrastructure/__main__.py` resolves under 9.29.0.

## Decision worth confirming
This standardizes on provider **9.x**. We could not read the last-deployed provider version from Pulumi state (state bucket auth is being refreshed), but the infra was likely last deployed on **7.x**. Consequences:
- **9.x (this PR):** verified against the code; first `pulumi preview` may show provider-upgrade diffs to review before `up`.
- **Alternative — pin 7.x** to minimize state churn: I'd re-verify the code against 7.x and adjust the cap. Say the word if you'd prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)